### PR TITLE
Force the character tree to have no node labels

### DIFF
--- a/R/AncStateEstMatrix.R
+++ b/R/AncStateEstMatrix.R
@@ -116,6 +116,9 @@ AncStateEstMatrix <- function(morph.matrix, tree, estimate.allchars=FALSE, estim
 
           }
 
+          # Remove any potential node labels on the character tree to avoid an error from rerootingMethod():
+          chartree$node.label<-NULL 
+
           # Get likelihoods for each state in taxa and ancestors:
           state.likelihoods <- rerootingMethod(chartree, tipvals.mat, model=mymodel)$marginal.anc
                     


### PR DESCRIPTION
Node labels in the character tree induce a bug message when using the rerootingMethod function. Note that it doesn't affect the input tree (that can still contain node labels).
